### PR TITLE
Determine the version of each prerequisite module

### DIFF
--- a/requirments.txt
+++ b/requirments.txt
@@ -1,4 +1,4 @@
-requests
-colorama
-ipapi
-builtwith
+requests==2.21.0
+colorama==0.4.6
+ipapi==1.0.4
+builtwith==1.3.4


### PR DESCRIPTION
Some lower versions are not compatible with Linux distributions, and some versions of modules are not compatible with Windows. Currently, these versions have been well tested on both Windows and Linux operating systems and are without problems. Therefore, for each prerequisite module, I set a compatible version with the program so that the program does not face inconsistency during the installation of the prerequisites file.